### PR TITLE
feat: 允许用户自定义配置随机插图清理的时间

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -123,5 +123,13 @@
       "default": 120,
       "min": 1,
       "max": 1440
+  },
+  "random_sent_illust_retention_days": {
+      "description": "随机搜索已发送作品保留天数,以避免重复发送",
+      "type": "int",
+      "hint": "已发送作品在数据库中保留的天数。单位：天。",
+      "default": 7,
+      "min": 1,
+      "max": 365
   }
 }

--- a/utils/config.py
+++ b/utils/config.py
@@ -91,6 +91,8 @@ class PixivConfig:
         self.subscription_check_interval_minutes = self.config.get("subscription_check_interval_minutes", 30)
         self.random_search_min_interval = self.config.get("random_search_min_interval", 60)
         self.random_search_max_interval = self.config.get("random_search_max_interval", 120)
+        self.random_sent_illust_retention_days = self.config.get("random_sent_illust_retention_days", 7)
+        
     
     def get_auth_error_message(self) -> str:
         """获取认证错误消息"""
@@ -150,6 +152,8 @@ class PixivConfigManager:
             "random_search_min_interval": {"type": "int", "min": 1, "max": 1440},
             "random_search_max_interval": {"type": "int", "min": 1, "max": 1440},
             "proxy": {"type": "string", "hidden": True},
+            "random_sent_illust_retention_days": {"type": "int", "min": 1, "max": 365}, 
+
         }
     
     def get_help_text(self) -> str:
@@ -167,7 +171,7 @@ class PixivConfigManager:
             "return_count", "r18_mode", "ai_filter_mode", "show_filter_result",
             "show_details", "deep_search_depth", "forward_threshold",
             "image_quality", "subscription_enabled", "random_search_min_interval",
-            "random_search_max_interval"
+            "random_search_max_interval", "random_sent_illust_retention_days"
         ]
         
         current = {}

--- a/utils/random_search.py
+++ b/utils/random_search.py
@@ -39,6 +39,7 @@ class RandomSearchService:
                 hour=2,  # 每天凌晨2点执行
                 minute=0
             )
+            
             self.scheduler.start()
             logger.info("Pixiv 随机搜索服务已启动。")
             
@@ -177,7 +178,11 @@ class RandomSearchService:
         """定期清理过期记录的任务"""
         try:
             logger.info("开始清理过期的已发送作品记录...")
-            cleanup_old_sent_illusts(days=1)
+            # 获取配置
+            days = self.plugin.pixiv_config.random_sent_illust_retention_days
+
+            # 使用 to_thread 防止数据库操作阻塞异步循环
+            await asyncio.to_thread(cleanup_old_sent_illusts, days=days)
             logger.info("清理过期记录任务完成。")
         except Exception as e:
             logger.error(f"清理过期记录任务出错: {e}")


### PR DESCRIPTION
改动说明：
之前 cleanup_old_sent_illusts 的清理时间硬编码为 1 天。
本次修改在配置文件中添加了 random_sent_illust_retention_days 选项，允许用户自定义保留天数（默认为 7 天）。
测试：
已通过指令验证配置可以成功读取和修改。