### PR TITLE
fix: 修复 pixiv_specific 参数传递错误导致配置失效的问题

### DIFF
--- a/handlers/illust.py
+++ b/handlers/illust.py
@@ -7,8 +7,9 @@ from ..utils.tag import (
     FilterConfig,
     validate_and_process_tags,
     process_and_send_illusts,
+    filter_illusts_with_reason
 )
-from ..utils.pixiv_utils import filter_items, send_pixiv_image, send_forward_message
+from ..utils.pixiv_utils import send_pixiv_image, send_forward_message
 
 from ..utils.help import get_help_message
 
@@ -473,9 +474,10 @@ class IllustHandler:
                 return_count=self.pixiv_config.return_count,
                 logger=logger,
                 show_filter_result=self.pixiv_config.show_filter_result,
+                show_details=self.pixiv_config.show_details,
                 excluded_tags=[],
             )
-            filtered_illusts, filter_msgs = filter_items([illust], config)
+            filtered_illusts, filter_msgs = filter_illusts_with_reason([illust], config)
             if self.pixiv_config.show_filter_result:
                 for msg in filter_msgs:
                     yield event.plain_result(msg)


### PR DESCRIPTION
### 问题描述
在 `pixiv_specific`（指定ID获取作品）指令的处理逻辑中，调用过滤函数 `filter_items` 时存在参数传递错误：
将 `FilterConfig` 配置对象错误地当作 `tag_label` (字符串) 传入了辅助函数。

这导致了两个问题：
1. **配置失效**：`filter_items` 内部忽略了传入的 `config` 对象，转而使用默认配置，导致用户针对该次请求的特定设置（如 R18 过滤、显示详情等）可能不生效。
2. **日志/消息异常**：用户收到的提示消息中会出现 `筛选完成，共找到 1 个符合所有标签「FilterConfig(...)」的作品` 这样冗长的对象字符串，而不是预期的 `ID:xxxxx`。

### 修改内容
* 修改了 `handlers/illust.py` 文件中的 `pixiv_specific` 方法。
* 弃用 `filter_items` 简便调用，改为直接调用底层的 `filter_illusts_with_reason`。
* 确保手动构建的 `FilterConfig` 对象被正确应用到过滤逻辑中。

### 测试结果
* 执行 `/pixiv_specific <ID>` 现在能正确显示标签名称（如 `ID:12345`）。
* 配置项（如 `show_details`）能正确生效。