### PR TITLE
feat(config): 添加API反代服务器配置选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@
 - [pixivpy3 官方文档](https://pypi.org/project/pixivpy3/)
 - [Pixiv OAuth 教程](https://gist.github.com/ZipFile/c9ebedb224406f4f11845ab700124362)
 
+### 部署反代服务（中国大陆用户）
+
+若无法使用代理且直连 Pixiv API 失败，可自建 Cloudflare Workers 反向代理：
+
+**仓库地址**: [vmoranv/pixiv-proxy](https://github.com/vmoranv/pixiv-proxy)
+
+**部署步骤**：
+
+1. 登录 [Cloudflare Dashboard](https://dash.cloudflare.com)
+2. 进入 **Workers & Pages** → **Create Application** → **Create Worker**
+3. 将 [pixiv-proxy.js](https://raw.githubusercontent.com/vmoranv/pixiv-proxy/main/pixiv-proxy.js) 的代码粘贴到编辑器中
+4. 点击 **Deploy** 部署
+5. 部署完成后复制 Worker 域名（如 `xxx.workers.dev`）
+6. 在插件配置中设置：
+   - `api_proxy_host` = `xxx.workers.dev`（用于 API 访问）
+   - 或 `image_proxy_host` = `xxx.workers.dev`（用于图片下载）
+
+> **提示**: 建议绑定自定义域名以避免 `workers.dev` 域名被墙
+
 ## 📝 使用示例
 
 ```bash
@@ -233,6 +252,8 @@
 **模块未找到**: 重启 AstrBot 以确保依赖正确安装
 
 **API 认证失败**: 检查 `refresh_token` 是否有效和正确配置
+
+**无代理直连失败**: 若在中国大陆无法使用代理且 ByPassSniApi 模式失效，可自建 Cloudflare Workers 反向代理。详见 [vmoranv/pixiv-proxy](https://github.com/vmoranv/pixiv-proxy) 仓库，部署后在插件配置中设置 `api_proxy_host` 为你的 Worker 域名。
 
 **Fanbox 帖子获取失败**: 可能触发 Cloudflare 或帖子受限。可先用 `/pixiv_fanbox_creator` 查看公开帖子，必要时配置 `fanbox_sessid`；若官方仍 403，建议同时配置 `fanbox_cookie`（完整 Cookie，含 `cf_clearance`）和 `fanbox_user_agent`（与浏览器一致）；也可切换 `fanbox_data_source=nekohouse` 仅走归档数据。
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -174,6 +174,13 @@
       "description": "无代理时自动使用图片反代服务器下载图片",
       "default": true
   },
+  "api_proxy_host": {
+      "type": "string",
+      "title": "Pixiv API 反代服务器",
+      "description": "用于替代 ByPassSniApi 的 API 反代服务器地址。格式：域名（如 example.com），无需 https://。留空则使用 ByPassSniApi 模式。",
+      "hint": "当 ByPassSniApi 失效时可使用自建或公开的 Pixiv API 反代。需支持 app-api.pixiv.net 和 oauth.secure.pixiv.net 的代理。",
+      "default": ""
+  },
   "random_search_min_interval": {
       "description": "随机搜索发送间隔最短时间（分钟）",
       "type": "int",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 id: astrbot_plugin_pixiv_reborn
 name: astrbot_plugin_pixiv_reborn
 author: vmoranv-reborn
-version: 1.6.1
+version: 1.7.0
 description: 通过标签在 Pixiv 上搜索插画。用法 /pixiv tag1,tag2,... 可在配置中设置认证信息、返回数量和 R18 过滤模式。
 repo: https://github.com/vmoranv-reborn/astrbot_plugin_pixiv_reborn

--- a/utils/config.py
+++ b/utils/config.py
@@ -123,6 +123,8 @@ class PixivConfig:
         # 新增：图片反代配置
         self.image_proxy_host = self.config.get("image_proxy_host", "i.pixiv.re")
         self.use_image_proxy = self.config.get("use_image_proxy", True)
+        # 新增：API 反代服务器配置（用于大陆直连替代 ByPassSniApi）
+        self.api_proxy_host = self.config.get("api_proxy_host", "").strip()
 
     def get_auth_error_message(self) -> str:
         """获取认证错误消息"""


### PR DESCRIPTION
新增api_proxy_host配置项，允许用户配置自定义的Pixiv API反代服务器，
替代ByPassSniApi模式，提高中国大陆用户的连接稳定性。

docs(README): 补充Cloudflare Workers反代部署指南

添加详细的自建Cloudflare Workers反向代理部署教程，包括仓库地址、
部署步骤和配置说明，帮助中国大陆用户解决直连失败问题。

fix(client): 优化Pixiv客户端连接策略

实现多方案连接机制，优先尝试直连，然后使用DoH解析，最后回退到
ByPassSniApi模式，并支持API反代服务器配置。