### PR TITLE
fix: 修复 AI 作品过滤误过滤普通作品

### DIFF
--- a/tests/test_tag_filters.py
+++ b/tests/test_tag_filters.py
@@ -10,19 +10,25 @@ def make_illust(
     total_bookmarks: int = 0,
     total_view: int = 0,
     like_count=None,
+    illust_ai_type: int | None = 0,
+    tags=None,
+    extra_fields=None,
 ):
     payload = {
         "id": illust_id,
         "title": f"illust-{illust_id}",
         "user": SimpleNamespace(name="tester"),
-        "tags": [],
+        "tags": tags or [],
         "x_restrict": 0,
-        "illust_ai_type": 0,
         "total_bookmarks": total_bookmarks,
         "total_view": total_view,
     }
+    if illust_ai_type is not None:
+        payload["illust_ai_type"] = illust_ai_type
     if like_count is not None:
         payload["likeCount"] = like_count
+    if extra_fields:
+        payload.update(extra_fields)
     return SimpleNamespace(**payload)
 
 
@@ -122,6 +128,65 @@ class TagFilterThresholdTests(unittest.TestCase):
         filtered, _ = filter_illusts_with_reason([make_novel(novel_id=1)], config)
 
         self.assertEqual([item.id for item in filtered], [1])
+
+    def test_ai_filter_keeps_illust_ai_type_one(self):
+        config = FilterConfig(
+            r18_mode="允许 R18",
+            ai_filter_mode="过滤 AI 作品",
+            show_filter_result=False,
+        )
+
+        filtered, _ = filter_illusts_with_reason(
+            [make_illust(illust_id=1, illust_ai_type=1)], config
+        )
+
+        self.assertEqual([item.id for item in filtered], [1])
+
+    def test_ai_filter_removes_illust_ai_type_two(self):
+        config = FilterConfig(
+            r18_mode="允许 R18",
+            ai_filter_mode="过滤 AI 作品",
+            show_filter_result=False,
+        )
+
+        filtered, _ = filter_illusts_with_reason(
+            [make_illust(illust_id=1, illust_ai_type=2)], config
+        )
+
+        self.assertEqual(filtered, [])
+
+    def test_ai_filter_reads_camel_case_ai_type(self):
+        config = FilterConfig(
+            r18_mode="允许 R18",
+            ai_filter_mode="过滤 AI 作品",
+            show_filter_result=False,
+        )
+
+        filtered, _ = filter_illusts_with_reason(
+            [
+                make_illust(
+                    illust_id=1,
+                    illust_ai_type=None,
+                    extra_fields={"illustAiType": 2},
+                )
+            ],
+            config,
+        )
+
+        self.assertEqual(filtered, [])
+
+    def test_ai_filter_falls_back_to_ai_tags(self):
+        config = FilterConfig(
+            r18_mode="允许 R18",
+            ai_filter_mode="过滤 AI 作品",
+            show_filter_result=False,
+        )
+
+        filtered, _ = filter_illusts_with_reason(
+            [make_illust(illust_id=1, tags=[{"name": "AI生成"}])], config
+        )
+
+        self.assertEqual(filtered, [])
 
 
 if __name__ == "__main__":

--- a/utils/config.py
+++ b/utils/config.py
@@ -88,7 +88,7 @@ class PixivConfig:
         self.refresh_token = self.config.get("refresh_token", None)
         self.return_count = self.config.get("return_count", 1)
         self.r18_mode = self.config.get("r18_mode", "过滤 R18")
-        self.ai_filter_mode = self.config.get("ai_filter_mode", "显示 AI 作品")
+        self.ai_filter_mode = self.config.get("ai_filter_mode", "过滤 AI 作品")
         self.min_bookmarks = self.config.get("min_bookmarks", 0)
         self.min_views = self.config.get("min_views", 0)
         self.min_likes = self.config.get("min_likes", 0)

--- a/utils/config.py
+++ b/utils/config.py
@@ -88,7 +88,7 @@ class PixivConfig:
         self.refresh_token = self.config.get("refresh_token", None)
         self.return_count = self.config.get("return_count", 1)
         self.r18_mode = self.config.get("r18_mode", "过滤 R18")
-        self.ai_filter_mode = self.config.get("ai_filter_mode", "过滤 AI 作品")
+        self.ai_filter_mode = self.config.get("ai_filter_mode", "显示 AI 作品")
         self.min_bookmarks = self.config.get("min_bookmarks", 0)
         self.min_views = self.config.get("min_views", 0)
         self.min_likes = self.config.get("min_likes", 0)

--- a/utils/tag.py
+++ b/utils/tag.py
@@ -145,7 +145,7 @@ def is_ai(item):
     ai_type = _to_int(
         _get_value(item, "illust_ai_type", "illustAiType", "ai_type", "aiType")
     )
-    if ai_type is not None and ai_type > 0:
+    if ai_type == 2:
         return True
 
     for name in _extract_tag_names(_get_value(item, "tags") or []):


### PR DESCRIPTION
## 摘要

更新后，在打开“AI 生成作品过滤模式”-“过滤 AI 作品”的时候会导致所有作品全部被过滤，无法返回任何搜索结果。

<img width="1651" height="489" alt="image" src="https://github.com/user-attachments/assets/a2203d3b-2103-47a8-b27d-782e5750b568" />

本PR: 

- 修复 AI 作品过滤逻辑，避免将 `illust_ai_type == 1` 的普通作品误判为 AI 作品。
- 现在仅当 `illust_ai_type == 2` 时按 AI 作品处理，同时保留 `AI生成` / `AI-generated` 等标签兜底判断。
- ~~将运行时 `ai_filter_mode` 默认值改为 `显示 AI 作品`，与 `_conf_schema.json` 保持一致。~~
- 增加 AI 过滤相关回归测试。

## 问题原因

该问题由提交 [`f6b7b9b feat(utils): 重构标签处理逻辑以支持多种数据格式` ](https://github.com/vmoranv-reborn/astrbot_plugin_pixiv_reborn/commit/f6b7b9b7f0c20e9e76e5dbba3c5dc4759d27a435) 引入。

该提交在 `utils/tag.py` 的 `is_ai()` 中新增了对 `illust_ai_type` 等字段的检测，但使用了 `ai_type > 0` 作为 AI 判定条件：

```python
if ai_type is not None and ai_type > 0:
    return True
```

但根据 https://github.com/upbit/pixivpy/blob/4f2e9ea7fff6247d9f5bfe5a862e92c5dfe3b6dd/demo.py#L168 ，`illust_ai_type == 1` 的作品是非AI作品，仅`illust_ai_type == 2` 的作品是标为AI生成的作品。因此开启“过滤 AI 作品”后，普通作品也会被误判为 AI 并全部过滤，导致搜索结果为空。

## 修复方式

将 AI 字段判定从“非 0 即 AI”调整为仅 `illust_ai_type == 2` 时判定为 AI：

```python
if ai_type == 2:
    return True
```

同时继续保留标签检测逻辑，避免漏掉明确带有 AI 标签但字段值不可靠的作品。

## 测试

已运行：

```bash
uv run python -m unittest tests.test_tag_filters
```

结果：

```text
Ran 8 tests in 0.000s

OK
```
