### PR TITLE
fix: add missing comma in config schema

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -86,6 +86,7 @@
           "field_only",
           "tag_only"
       ]
+  },
   "min_bookmarks": {
       "description": "最小书签数过滤阈值",
       "type": "int",


### PR DESCRIPTION
Prevent JSON parse failures by closing the ai_detection_mode object before min_bookmarks.

仅语法热修复，GitHub的自动解决冲突漏掉了一个逗号，实在抱歉