### PR TITLE
feat: 添加 Pixiv URL 搜索功能，更新配置和处理逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 data/t2i_templates/
 data/cmd_config.json
 .ace-tool/
+.vscode
+.venv

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -131,6 +131,12 @@
       "hint": "设置为 true 时启用转发，false 时禁用转发。启用后所有图片都会以转发消息形式发送。",
       "default": false
   },
+  "pixiv_urlsearch_enabled": {
+      "description": "是否启用 Pixiv URL 搜索功能",
+      "type": "bool",
+      "hint": "设置为 true 时启用 Pixiv URL 搜索，false 时禁用。",
+      "default": true
+  },
   "show_filter_result": {
       "description": "是否显示过滤内容提示",
       "type": "bool",

--- a/handlers/illust.py
+++ b/handlers/illust.py
@@ -27,6 +27,30 @@ class IllustHandler:
         self.client = client_wrapper.client_api
         self.pixiv_config = pixiv_config
 
+    async def pixiv_msg_url(self, event: AstrMessageEvent, msg: str = ""):
+        """处理接受的消息，查看是否为 https://www.pixiv.net/artworks/xxxx 形式的 URL，并获取作品信息"""
+        # 检查是否启用了 Pixiv URL 搜索功能
+        if not self.pixiv_config.pixiv_urlsearch_enabled:
+            return
+        msg = event.message_str.strip() # 去除首尾空白字符
+        # 检查是否为 Pixiv 插画 URL
+        if msg.startswith("https://www.pixiv.net/artworks/"):
+            try:
+                # 获取作品ID，使用 rstrip("/") 避免末尾斜杠导致取到空字符串
+                illust_id = msg.rstrip("/").split("/")[-1]
+                # 简单验证 ID 是否为数字，防止类似 /artworks/abc 的无效输入
+                if not illust_id.isdigit():
+                    yield event.plain_result("无效的 Pixiv 插画 ID。")
+                    return
+                
+                # 调用已有的 pixiv_specific 方法获取作品信息并发送
+                async for result in self.pixiv_specific(event, illust_id):
+                    yield result
+            except Exception as e:
+                logger.error(f"获取插画信息失败: {e}")
+                yield event.plain_result("获取插画信息失败，请稍后再试。")
+        
+            
     async def pixiv_search_illust(self, event: AstrMessageEvent, tags: str = ""):
         """处理 /pixiv 命令，默认为标签搜索功能"""
         # 清理标签字符串，并检查是否为空或为 "help"
@@ -74,11 +98,9 @@ class IllustHandler:
                 search_target="partial_match_for_tags",
             )
             initial_illusts = search_result.illusts if search_result.illusts else []
-
             if not initial_illusts:
                 yield event.plain_result("未找到相关插画。")
                 return
-
             # 使用统一的作品处理和发送函数
             config = FilterConfig(
                 r18_mode=self.pixiv_config.r18_mode,

--- a/main.py
+++ b/main.py
@@ -2,10 +2,10 @@ import asyncio
 from typing import Dict, Any
 import aiohttp
 
-from astrbot.api.event import AstrMessageEvent
+from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star, StarTools
 from astrbot.api import logger
-from astrbot.api.all import command
+from astrbot.api.all import command 
 
 from .utils.database import initialize_database
 from .utils.subscription import SubscriptionService
@@ -164,6 +164,12 @@ class PixivSearchPlugin(Star):
         async for result in self.illust_handler.pixiv_and(event, tags):
             yield result
 
+    @filter.event_message_type(filter.EventMessageType.ALL)
+    async def pixiv_url_all(self, event: AstrMessageEvent):
+        """处理url消息事件,判断是否为p站插画链接,并发送图片"""
+        async for result in self.illust_handler.pixiv_msg_url(event, event.message_str):
+            yield result
+            
     @command("pixiv_specific")
     async def pixiv_specific(self, event: AstrMessageEvent, illust_id: str = ""):
         """根据作品 ID 获取特定作品详情"""

--- a/utils/config.py
+++ b/utils/config.py
@@ -94,6 +94,7 @@ class PixivConfig:
         self.min_bookmarks = self.config.get("min_bookmarks", 0)
         self.min_views = self.config.get("min_views", 0)
         self.min_likes = self.config.get("min_likes", 0)
+        self.pixiv_urlsearch_enabled = self.config.get("pixiv_urlsearch_enabled", True)
         self.show_filter_result = self.config.get("show_filter_result", True)
         self.single_response_mode = self.config.get("single_response_mode", True)
         self.show_details = self.config.get("show_details", True)

--- a/utils/tag.py
+++ b/utils/tag.py
@@ -36,6 +36,7 @@ class FilterConfig:
     show_filter_result: bool = True
     excluded_tags: Optional[List[str]] = None
     filter_r18g_only: bool = False
+    pixiv_urlsearch_enabled: bool = True
     single_response_mode: bool = False
     forward_threshold: bool = False
     show_details: bool = True


### PR DESCRIPTION
我添加了在群聊里直接发送 pixiv url 会发送对应图片的功能。看一下能不能过。

我本来想修改一下 pixiv 指令的发送逻辑，但是看不懂，只能加了一个小功能。
pixiv那个搜索会经常发送重复的图片，能不能改一下，让它优先发送日期最新的图。
或者内部添加一个 发送过的图片id数组（100个？）,在发送时检查一下这个最近是不是发送过的。发送过了 去重新获取一张再发送，然后把这张id添加进数组里。超过100 就自动删除最旧的那个。