### PR TITLE
fix(client): token 刷新中的同步 auth 调用移入线程，避免阻塞事件循环 

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -140,7 +140,10 @@ class PixivClientWrapper:
 
                 logger.info("Pixiv Token 刷新任务：尝试使用 Refresh Token 进行认证...")
                 try:
-                    self.client_api.auth(refresh_token=current_refresh_token)
+                    # 使用 to_thread 将同步网络调用移出事件循环，避免 ssl.read() 阻塞卡死整个 Bot
+                    await asyncio.to_thread(
+                        self.client_api.auth, refresh_token=current_refresh_token
+                    )
                     logger.info("Pixiv Token 刷新任务：认证调用成功。")
 
                 except PixivError as pe:


### PR DESCRIPTION
fix #49 

### 问题
`periodic_token_refresh()` 直接同步调用 `self.client_api.auth()`，在事件循环线程上执行阻塞网络请求。当出现"TCP 连接建立 + SSL 握手完成但服务端不发送响应"的特定网络故障时，`ssl.read()` 无限阻塞，卡死整个事件循环，导致 Bot 完全无响应。

### 修复
采用 issue 中方案一：将同步 `auth()` 调用包装为 `await asyncio.to_thread(...)`，与 `authenticate()` 方法中的既有写法保持一致。阻塞网络调用移入工作线程，不再影响事件循环。

### 验证
- `python -m py_compile` 语法检查通过
- 已确认代码中无其他未包装的同步 `auth()` 调用